### PR TITLE
feat: getDeletedFiles method [BACKLOG-42315]

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>pentaho</groupId>
     <artifactId>pentaho-generic-file-system-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pentaho-generic-file-system-api</artifactId>

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/GenericFilePath.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/GenericFilePath.java
@@ -91,6 +91,18 @@ public class GenericFilePath {
   }
 
   /**
+   * Gets the path last segment.
+   * <p>
+   * The last segment is that which identifies the path's file or folder name.
+   *
+   * @return The last segment.
+   */
+  @NonNull
+  public String getLastSegment() {
+    return segments.get( segments.size() - 1 );
+  }
+
+  /**
    * Gets a value that indicates if the path has a scheme.
    * <p>
    * For more information, see {@link #getFirstSegment()}.

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -23,6 +23,7 @@ import org.pentaho.platform.api.genericfile.model.IGenericFile;
 import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -185,4 +186,16 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    */
   @NonNull
   IGenericFile getFile( @NonNull GenericFilePath path ) throws OperationFailedException;
+
+  /**
+   * Gets a list of deleted files which are still available in the trash folder.
+   *
+   * @return The list of deleted files.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  @NonNull
+  default List<IGenericFile> getDeletedFiles() throws OperationFailedException {
+    return Collections.emptyList();
+  }
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -24,6 +24,7 @@ import org.pentaho.platform.api.genericfile.model.IGenericFile;
 import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -275,4 +276,14 @@ public interface IGenericFileService {
    */
   @NonNull
   IGenericFile getFile( @NonNull GenericFilePath path ) throws OperationFailedException;
+
+  /**
+   * Gets a list of deleted files which are still available in the trash folder.
+   *
+   * @return The list of deleted files.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  @NonNull
+  List<IGenericFile> getDeletedFiles() throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFile.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFile.java
@@ -14,6 +14,7 @@
 package org.pentaho.platform.api.genericfile.model;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  * The {@code IGenericFile} interface contains basic information about a generic file.
@@ -107,6 +108,26 @@ public interface IGenericFile extends IProviderable {
   boolean isCanEdit();
 
   /**
+   * Gets the original location of the generic file before it was deleted.
+   * <p>
+   * Each `IGenericFile` in the list corresponds to a folder in the path hierarchy
+   * from the root to the original parent folder of the deleted file.
+   * <p>
+   * Note: Some folders in the original location may not exist anymore.
+   */
+  List<IGenericFile> getOriginalLocation();
+
+  /**
+   * Gets the deleted date of the generic file.
+   */
+  Date getDeletedDate();
+
+  /**
+   * Gets the user that deleted the generic file.
+   */
+  String getDeletedBy();
+
+  /**
    * Gets whether the generic file can be deleted.
    */
   boolean isCanDelete();
@@ -136,4 +157,9 @@ public interface IGenericFile extends IProviderable {
    * @see #getTitle()
    */
   String getDescription();
+
+  /**
+   * Gets the owner of the generic file.
+   */
+  String getOwner();
 }

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -72,12 +72,21 @@ class IGenericFileServiceTest {
       throw new UnsupportedOperationException();
     }
 
-    @Override public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path ) {
+    @NonNull
+    @Override
+    public IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path ) {
       throw new UnsupportedOperationException();
     }
 
+    @NonNull
     @Override
     public IGenericFile getFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public List<IGenericFile> getDeletedFiles() {
       throw new UnsupportedOperationException();
     }
   }

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>pentaho</groupId>
     <artifactId>pentaho-generic-file-system-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pentaho-generic-file-system-impl</artifactId>

--- a/impl/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
@@ -305,12 +305,4 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
     cachedTrees.put( cacheOptions, tree );
   }
   // endregion
-
-  @Override
-  public abstract IGenericFileContentWrapper getFileContentWrapper( @NonNull GenericFilePath path )
-    throws OperationFailedException;
-
-  @NonNull
-  @Override
-  public abstract IGenericFile getFile( @NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/impl/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFile.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFile.java
@@ -17,6 +17,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import org.pentaho.platform.api.genericfile.model.IGenericFile;
 
 import java.util.Date;
+import java.util.List;
 
 public class BaseGenericFile implements IGenericFile {
   private String provider;
@@ -26,9 +27,13 @@ public class BaseGenericFile implements IGenericFile {
   private String type;
   private Date modifiedDate;
   private boolean canEdit;
+  private Date deletedDate;
+  private String deletedBy;
   private boolean canDelete;
+  private List<IGenericFile> originalLocation;
   private String title;
   private String description;
+  private String owner;
 
   @NonNull
   @Override
@@ -95,6 +100,33 @@ public class BaseGenericFile implements IGenericFile {
   }
 
   @Override
+  public List<IGenericFile> getOriginalLocation() {
+    return originalLocation;
+  }
+
+  public void setOriginalLocation( List<IGenericFile> originalLocation ) {
+    this.originalLocation = originalLocation;
+  }
+
+  @Override
+  public Date getDeletedDate() {
+    return deletedDate;
+  }
+
+  public void setDeletedDate( Date deletedDate ) {
+    this.deletedDate = deletedDate;
+  }
+
+  @Override
+  public String getDeletedBy() {
+    return deletedBy;
+  }
+
+  public void setDeletedBy( String deletedBy ) {
+    this.deletedBy = deletedBy;
+  }
+
+  @Override
   public boolean isCanDelete() {
     return canDelete;
   }
@@ -119,5 +151,14 @@ public class BaseGenericFile implements IGenericFile {
 
   public void setDescription( String description ) {
     this.description = description;
+  }
+
+  @Override
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner( String owner ) {
+    this.owner = owner;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>pentaho</groupId>
   <artifactId>pentaho-generic-file-system-parent</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
@pentaho/millenniumfalcon please review

This pull request includes several changes to the `pentaho-generic-file-system` project, primarily focusing on adding new methods and properties related to handling deleted files and their metadata. Additionally, there are updates to the project version in the `pom.xml` files.

### Key Changes:

#### New Methods and Properties:
* [`api/src/main/java/org/pentaho/platform/api/genericfile/GenericFilePath.java`](diffhunk://#diff-9ed03c7cd42554afd3350cd5eccd0abe37381eab57c97b9a62b56df3232844e2R93-R104): Added `getLastSegment` method to retrieve the last segment of a file path.
* [`api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java`](diffhunk://#diff-be0fe333a36a507d46b3fb7aa0d6f5861eba6de460dafd85c7b8bff36cc390caR189-R200): Introduced `getDeletedFiles` method to fetch deleted files from the trash folder.
* [`api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java`](diffhunk://#diff-f742989aab35fb0c0cdd91e9788f1ac39f634b7bb1c5134377c92c181ddac60dR279-R288): Added `getDeletedFiles` method to the service interface.
* [`api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFile.java`](diffhunk://#diff-6fdfe802084a2110867b50a7f34d8192bb259c50ff85a5818801f2f873418346R110-R129): Added methods `getOriginalLocation`, `getDeletedDate`, `getDeletedBy`, and `getOwner` to handle metadata of deleted files. [[1]](diffhunk://#diff-6fdfe802084a2110867b50a7f34d8192bb259c50ff85a5818801f2f873418346R110-R129) [[2]](diffhunk://#diff-6fdfe802084a2110867b50a7f34d8192bb259c50ff85a5818801f2f873418346R160-R164)

#### Implementation Updates:
* [`impl/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java`](diffhunk://#diff-34c6ad546ad414c59a38f9c307f731b9c83df8c7dd0bc09c160acd34194c98a6R208-R237): Implemented the `getDeletedFiles` method to aggregate deleted files from multiple providers.
* [`impl/src/main/java/org/pentaho/platform/genericfile/model/BaseGenericFile.java`](diffhunk://#diff-0e9f6c2827484d62448615151f6a7cb438f450f9f7ab28c48223f5ecd992a007R30-R36): Added properties and corresponding getter/setter methods for `deletedDate`, `deletedBy`, `originalLocation`, and `owner`. [[1]](diffhunk://#diff-0e9f6c2827484d62448615151f6a7cb438f450f9f7ab28c48223f5ecd992a007R30-R36) [[2]](diffhunk://#diff-0e9f6c2827484d62448615151f6a7cb438f450f9f7ab28c48223f5ecd992a007R102-R128) [[3]](diffhunk://#diff-0e9f6c2827484d62448615151f6a7cb438f450f9f7ab28c48223f5ecd992a007R155-R163)

#### Project Version Updates:
* `api/pom.xml` and `impl/pom.xml`: Updated the project version from `1.0.1-SNAPSHOT` to `1.1.0-SNAPSHOT`. [[1]](diffhunk://#diff-f35103f068e191d5d8933637b2d4217d8f90a78728ccab1bada951a8d1c83590L10-R10) [[2]](diffhunk://#diff-abb4e0d98dcc6e2742e9b46d0f75f831b0e0dbe1feac6a85ebf38167130528a9L10-R10)

These changes enhance the functionality of the file system by introducing capabilities to manage and retrieve information about deleted files, as well as updating the project version to reflect these new features.