### PR TITLE
feat: restoreFiles and deleteFiles method [PPUC-57][PPUC-27]

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>pentaho</groupId>
     <artifactId>pentaho-generic-file-system-parent</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pentaho-generic-file-system-api</artifactId>

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -217,4 +217,13 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException;
+
+  /**
+   * Restores a file given its path.
+   *
+   * @param path The path of the file to be restored.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  void restoreFile( @NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -208,4 +208,13 @@ public interface IGenericFileProvider<T extends IGenericFile> {
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   void deleteFilePermanently( @NonNull GenericFilePath path ) throws OperationFailedException;
+
+  /**
+   * Deletes a file by sending it to the trash, given its path.
+   *
+   * @param path The path of the file to be deleted.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -16,6 +16,7 @@ package org.pentaho.platform.api.genericfile;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.pentaho.platform.api.genericfile.exception.AccessControlException;
+import org.pentaho.platform.api.genericfile.exception.BatchOperationFailedException;
 import org.pentaho.platform.api.genericfile.exception.InvalidOperationException;
 import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
 import org.pentaho.platform.api.genericfile.exception.NotFoundException;
@@ -291,11 +292,44 @@ public interface IGenericFileService {
   List<IGenericFile> getDeletedFiles() throws OperationFailedException;
 
   /**
-   * Permanently deletes files given their paths.
+   * Permanently deletes files, given their paths.
    *
-   * @param paths The list of file paths to be permanently deleted.
-   * @throws AccessControlException   If the current user cannot perform this operation.
-   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   * @param paths The list of file paths to be permanently deleted. These paths must correspond to files that are in the trash/deleted.
+   * @throws AccessControlException        If the current user cannot perform this operation.
+   * @throws BatchOperationFailedException If the batch operation fails for some reason.
+   * @throws OperationFailedException      If the operation fails for some other (checked) reason.
    */
   void deleteFilesPermanently( @NonNull List<GenericFilePath> paths ) throws OperationFailedException;
+
+  /**
+   * Permanently deletes a file, given its path.
+   *
+   * @param path The file path to be permanently deleted. This path must correspond to a file that is in the trash/deleted.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws InvalidPathException     If the specified path is not valid.
+   * @throws NotFoundException        If the specified path does not exist, or does not correspond to a file that 
+   *                                  are in the trash/deleted, or the current user is not allowed to access it.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  void deleteFilePermanently( @NonNull GenericFilePath path ) throws OperationFailedException;
+
+  /**
+   * Deletes files by sending them to the trash, given their paths.
+   *
+   * @param paths The list of file paths to be deleted.
+   * @throws AccessControlException        If the current user cannot perform this operation.
+   * @throws BatchOperationFailedException If the batch operation fails for some reason.
+   * @throws OperationFailedException      If the operation fails for some other (checked) reason.
+   */
+  void deleteFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException;
+
+  /**
+   * Deletes a file by sending it to the trash, given its path.
+   *
+   * @param path The file path to be deleted.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws NotFoundException        If the specified path does not exist, or the current user is not allowed to access it.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -332,4 +332,26 @@ public interface IGenericFileService {
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException;
+
+  /**
+   * Restores files, given their paths.
+   *
+   * @param paths The list of file paths to be restored. These paths must correspond to files that are in the trash/deleted.
+   * @throws AccessControlException        If the current user cannot perform this operation.
+   * @throws BatchOperationFailedException If the batch operation fails for some reason.
+   * @throws OperationFailedException      If the operation fails for some other (checked) reason.
+   */
+  void restoreFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException;
+
+  /**
+   * Restores a file, given its path.
+   *
+   * @param path The file path to be restored. This path must correspond to a file that is in the trash/deleted.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws InvalidPathException     If the specified path is not valid.
+   * @throws NotFoundException        If the specified path does not exist, or does not correspond to a file that 
+   *                                  are in the trash/deleted, or the current user is not allowed to access it.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  void restoreFile( @NonNull GenericFilePath path ) throws OperationFailedException;
 }

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/exception/BatchOperationFailedException.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/exception/BatchOperationFailedException.java
@@ -6,10 +6,10 @@ import org.pentaho.platform.api.genericfile.GenericFilePath;
 import java.util.HashMap;
 import java.util.Map;
 
-public class BatchDeleteOperationFailedException extends OperationFailedException {
+public class BatchOperationFailedException extends OperationFailedException {
   private final transient Map<GenericFilePath, Exception> failedFiles;
 
-  public BatchDeleteOperationFailedException( String message ) {
+  public BatchOperationFailedException( String message ) {
     super( message );
     this.failedFiles = new HashMap<>();
   }

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -109,6 +109,16 @@ class IGenericFileServiceTest {
     public void deleteFile(@NonNull GenericFilePath path) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void restoreFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void restoreFile(@NonNull GenericFilePath path) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /**

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -94,6 +94,21 @@ class IGenericFileServiceTest {
     public void deleteFilesPermanently( @NonNull List<GenericFilePath> paths ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void deleteFilePermanently(@NonNull GenericFilePath path) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteFile(@NonNull GenericFilePath path) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /**

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>pentaho</groupId>
     <artifactId>pentaho-generic-file-system-parent</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pentaho-generic-file-system-impl</artifactId>

--- a/impl/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
@@ -294,4 +294,33 @@ public class DefaultGenericFileService implements IGenericFileService {
       .orElseThrow( () -> new NotFoundException( String.format( "Path not found '%s'.", path ) ) )
       .deleteFile( path );
   }
+
+  @Override
+  public void restoreFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException {
+    BatchOperationFailedException batchException = null;
+
+    for ( GenericFilePath path : paths ) {
+      try {
+        restoreFile( path );
+      } catch ( OperationFailedException e ) {
+        if ( batchException == null ) {
+          batchException =
+            new BatchOperationFailedException( "Error(s) occurred while attempting to restore." );
+        }
+
+        batchException.addFailedPath( path, e );
+      }
+    }
+
+    if ( batchException != null ) {
+      throw batchException;
+    }
+  }
+
+  @Override
+  public void restoreFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+    getOwnerFileProvider( path )
+      .orElseThrow( () -> new NotFoundException( String.format( "Path not found '%s'.", path ) ) )
+      .restoreFile( path );
+  }
 }

--- a/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
@@ -513,6 +513,17 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
     }
   }
 
+  @Override
+  public void restoreFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+    String fileId = getTrashFileId( path );
+
+    try {
+      fileService.doRestoreFiles( fileId );
+    } catch ( Exception | InternalError e ) {
+      throw new OperationFailedException( e );
+    }
+  }
+
   protected String getFileId( @NonNull GenericFilePath path ) throws FileNotFoundException {
     return fileService.doGetProperties( encodeRepositoryPath( path.toString() ) ).getId();
   }

--- a/impl/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
@@ -86,6 +86,10 @@ public class BaseGenericFileProviderTest {
       throw new UnsupportedOperationException();
     }
 
+    @Override
+    public void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
     @NonNull
     @Override
     public Class<T> getFileClass() {

--- a/impl/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
@@ -90,6 +90,12 @@ public class BaseGenericFileProviderTest {
     public void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void restoreFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+      throw new UnsupportedOperationException();
+    }
+
     @NonNull
     @Override
     public Class<T> getFileClass() {

--- a/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
@@ -856,4 +856,56 @@ public class RepositoryFileProviderTest {
     return file;
   }
   // endregion
+
+  // region restoreFile
+  @Test
+  public void testRestoreFileSuccess() throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/home/admin/.trash/pho:8b69da2b-2a10-4a82-89bc-a376e52d5482"
+      + "/PAZReport.xanalyzer" );
+
+    FileService fileServiceMock = mock( FileService.class );
+    doNothing().when( fileServiceMock ).doRestoreFiles( any() );
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
+
+    repositoryProvider.restoreFile( path );
+
+    verify( fileServiceMock, times( 1 ) ).doRestoreFiles( repositoryProvider.getTrashFileId( path ) );
+  }
+
+  @Test
+  public void testRestoreFileInvalidPath() throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/home/admin/pho:8b69da2b-2a10-4a82-89bc-a376e52d5482"
+      + "/PAZReport.xanalyzer" );
+
+    FileService fileServiceMock = mock( FileService.class );
+    doNothing().when( fileServiceMock ).doRestoreFiles( any() );
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
+
+    NotFoundException exception = assertThrows( NotFoundException.class, () ->
+      repositoryProvider.restoreFile( path )
+    );
+
+    assertEquals( "The path does not correspond to a deleted file.", exception.getMessage() );
+    verify( fileServiceMock, never() ).doRestoreFiles( anyString() );
+  }
+
+  @Test
+  public void testRestoreFileOperationFailed() throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/home/admin/.trash/pho:8b69da2b-2a10-4a82-89bc-a376e52d5482"
+      + "/PAZReport.xanalyzer" );
+
+    FileService fileServiceMock = mock( FileService.class );
+    doNothing().when( fileServiceMock ).doRestoreFiles( any() );
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
+
+    doThrow( new InternalError() ).when( fileServiceMock ).doRestoreFiles( any() );
+
+    assertThrows( OperationFailedException.class, () -> repositoryProvider.restoreFile( path ) );
+
+    verify( fileServiceMock ).doRestoreFiles( repositoryProvider.getTrashFileId( path ) );
+  }
+  // endregion
 }

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>pentaho</groupId>
   <artifactId>pentaho-generic-file-system-parent</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
@pentaho/millenniumfalcon please review

This pull request introduces significant enhancements to the file management system, including the addition of new methods for soft deletion and restoration of files, a refactor of exception handling for batch operations, and updates to tests to cover the new functionality. These changes improve the system's flexibility and robustness when managing files.

### New Features
* Added `deleteFile` and `restoreFile` methods to the `IGenericFileProvider` and `IGenericFileService` interfaces, enabling soft deletion (moving files to trash) and restoration of files. These methods include appropriate exception handling for access control and operation failures. [[1]](diffhunk://#diff-be0fe333a36a507d46b3fb7aa0d6f5861eba6de460dafd85c7b8bff36cc390caR211-R228) [[2]](diffhunk://#diff-f742989aab35fb0c0cdd91e9788f1ac39f634b7bb1c5134377c92c181ddac60dR301-R318) [[3]](diffhunk://#diff-44974625ff45ff0f032a66db8e99fb8e1437ccd263c1772407ee70d1f8bf70b7R507-R530)

### Refactoring
* Renamed `BatchDeleteOperationFailedException` to `BatchOperationFailedException` to generalize its purpose for both deletion and restoration operations. Updated all references and constructors accordingly. [[1]](diffhunk://#diff-3572ccaaca4f2304ee4f143a89137676cc21aa6950904480920d3230813303c5L9-R12) [[2]](diffhunk://#diff-34c6ad546ad414c59a38f9c307f731b9c83df8c7dd0bc09c160acd34194c98a6L23-R23) [[3]](diffhunk://#diff-34c6ad546ad414c59a38f9c307f731b9c83df8c7dd0bc09c160acd34194c98a6L242-R242) [[4]](diffhunk://#diff-34c6ad546ad414c59a38f9c307f731b9c83df8c7dd0bc09c160acd34194c98a6L252-R300) [[5]](diffhunk://#diff-3c1cef1e389a979865b28d74c5bfb85130b13e6531c2b522563b0c55b90040feL19-R19) [[6]](diffhunk://#diff-3c1cef1e389a979865b28d74c5bfb85130b13e6531c2b522563b0c55b90040feL409-R414) [[7]](diffhunk://#diff-3c1cef1e389a979865b28d74c5bfb85130b13e6531c2b522563b0c55b90040feL430-R436)

### Implementation Enhancements
* Implemented the `deleteFiles` and `restoreFiles` methods in `DefaultGenericFileService` to handle batch operations for soft deletion and restoration of files. These methods ensure that errors for individual files are captured and thrown as a `BatchOperationFailedException`.

### Testing Improvements
* Added comprehensive unit tests for the new `deleteFiles` and `restoreFiles` methods, including scenarios for successful operations, path not found errors, and operation failures. This ensures robust coverage for the newly introduced functionality. [[1]](diffhunk://#diff-3c1cef1e389a979865b28d74c5bfb85130b13e6531c2b522563b0c55b90040feR446-R589) [[2]](diffhunk://#diff-1b0adee8a518ca86ed7b808fbfe834a4531fd4b8375b8c1f033734fe9fd03995R89-R98) [[3]](diffhunk://#diff-679590a35540309b950273740a059394780179ef15a73f7bdd1cfd80960342baR97-R106)

### Dependency Updates
* Updated the version of `pentaho-generic-file-system-parent` in `pom.xml` files from `1.2.1-SNAPSHOT` to `1.3.0-SNAPSHOT` to reflect the new features and changes. [[1]](diffhunk://#diff-f35103f068e191d5d8933637b2d4217d8f90a78728ccab1bada951a8d1c83590L10-R10) [[2]](diffhunk://#diff-abb4e0d98dcc6e2742e9b46d0f75f831b0e0dbe1feac6a85ebf38167130528a9L10-R10)