### PR TITLE
feat(backend): add permanent flag to deleteFiles method [PPUC-27]

### DIFF
--- a/api/src/main/java/org/pentaho/platform/api/genericfile/GetTreeOptions.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/GetTreeOptions.java
@@ -62,6 +62,7 @@ public class GetTreeOptions {
 
     /**
      * Returns true if the file type passes the filter
+     *
      * @param isFolder
      * @return
      */
@@ -90,6 +91,7 @@ public class GetTreeOptions {
 
   /**
    * Copy constructor.
+   *
    * @param other The options instance from which to initialize this instance.
    */
   public GetTreeOptions( @NonNull GetTreeOptions other ) {
@@ -297,6 +299,7 @@ public class GetTreeOptions {
    * Gets a value that indicates whether hidden files are included in the result.
    * <p>
    * Defaults to {@code false}.
+   *
    * @return {@code true} to include hidden files; {@code false}, otherwise.
    */
   public boolean isIncludeHidden() {

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileProvider.java
@@ -201,27 +201,40 @@ public interface IGenericFileProvider<T extends IGenericFile> {
   }
 
   /**
-   * Permanently deletes a file given its path.
+   * Permanently deletes a file, given its path.
    *
-   * @param path The path of the file to be permanently deleted.
+   * @param path The file path to be permanently deleted. This path must correspond to a file in the trash/deleted.
    * @throws AccessControlException   If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   void deleteFilePermanently( @NonNull GenericFilePath path ) throws OperationFailedException;
 
   /**
-   * Deletes a file by sending it to the trash, given its path.
+   * Deletes a file, given its path, by sending it to the trash or permanently deleting it, depending on the value of
+   * the {@code permanent} variable.
    *
-   * @param path The path of the file to be deleted.
+   * @param path      The file path to be deleted. This path must not correspond to a file in the trash/deleted.
+   * @param permanent If {@code true}, the file is permanently deleted; if {@code false}, the file is sent to the trash.
    * @throws AccessControlException   If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
-  void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException;
+  void deleteFile( @NonNull GenericFilePath path, boolean permanent ) throws OperationFailedException;
 
   /**
-   * Restores a file given its path.
+   * Deletes a file, given its path, by sending it to the trash.
    *
-   * @param path The path of the file to be restored.
+   * @param path The file path to be deleted. This path must not correspond to a file in the trash/deleted.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  default void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+    deleteFile( path, false );
+  }
+
+  /**
+   * Restores a file, given its path.
+   *
+   * @param path The file path to be restored. This path must correspond to a file in the trash/deleted.
    * @throws AccessControlException   If the current user cannot perform this operation.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/IGenericFileService.java
@@ -294,7 +294,8 @@ public interface IGenericFileService {
   /**
    * Permanently deletes files, given their paths.
    *
-   * @param paths The list of file paths to be permanently deleted. These paths must correspond to files that are in the trash/deleted.
+   * @param paths The list of file paths to be permanently deleted. These paths must correspond to files that are in
+   *              the trash/deleted.
    * @throws AccessControlException        If the current user cannot perform this operation.
    * @throws BatchOperationFailedException If the batch operation fails for some reason.
    * @throws OperationFailedException      If the operation fails for some other (checked) reason.
@@ -304,39 +305,72 @@ public interface IGenericFileService {
   /**
    * Permanently deletes a file, given its path.
    *
-   * @param path The file path to be permanently deleted. This path must correspond to a file that is in the trash/deleted.
+   * @param path The file path to be permanently deleted. This path must correspond to a file in the trash/deleted.
    * @throws AccessControlException   If the current user cannot perform this operation.
    * @throws InvalidPathException     If the specified path is not valid.
-   * @throws NotFoundException        If the specified path does not exist, or does not correspond to a file that 
-   *                                  are in the trash/deleted, or the current user is not allowed to access it.
+   * @throws NotFoundException        If the specified path does not exist, or does not correspond to a file in the
+   *                                  trash/deleted, or the current user is not allowed to access it.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   void deleteFilePermanently( @NonNull GenericFilePath path ) throws OperationFailedException;
 
   /**
-   * Deletes files by sending them to the trash, given their paths.
+   * Deletes files, given their paths, by sending them to the trash or permanently deleting them, depending on the
+   * value of the {@code permanent} variable.
    *
-   * @param paths The list of file paths to be deleted.
+   * @param paths     The list of file paths to be deleted. These paths must not correspond to files that are in the
+   *                  trash/deleted.
+   * @param permanent If {@code true}, the file is permanently deleted; if {@code false}, the file is sent to the trash.
    * @throws AccessControlException        If the current user cannot perform this operation.
    * @throws BatchOperationFailedException If the batch operation fails for some reason.
    * @throws OperationFailedException      If the operation fails for some other (checked) reason.
    */
-  void deleteFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException;
+  void deleteFiles( @NonNull List<GenericFilePath> paths, boolean permanent ) throws OperationFailedException;
 
   /**
-   * Deletes a file by sending it to the trash, given its path.
+   * Deletes files, given their paths, by sending them to the trash.
    *
-   * @param path The file path to be deleted.
+   * @param paths The list of file paths to be deleted. These paths must not correspond to files that are in the
+   *              trash/deleted.
+   * @throws AccessControlException        If the current user cannot perform this operation.
+   * @throws BatchOperationFailedException If the batch operation fails for some reason.
+   * @throws OperationFailedException      If the operation fails for some other (checked) reason.
+   */
+  default void deleteFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException {
+    deleteFiles( paths, false );
+  }
+
+  /**
+   * Deletes a file, given its path, by sending it to the trash or permanently deleting it, depending on the value of
+   * the {@code permanent} variable.
+   *
+   * @param path      The file path to be deleted. This path must not correspond to a file in the trash/deleted.
+   * @param permanent If {@code true}, the file is permanently deleted; if {@code false}, the file is sent to the trash.
    * @throws AccessControlException   If the current user cannot perform this operation.
-   * @throws NotFoundException        If the specified path does not exist, or the current user is not allowed to access it.
+   * @throws NotFoundException        If the specified path does not exist, or the current user is not allowed to
+   *                                  access it.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
-  void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException;
+  void deleteFile( @NonNull GenericFilePath path, boolean permanent ) throws OperationFailedException;
+
+  /**
+   * Deletes a file, given its path, by sending it to the trash.
+   *
+   * @param path The file path to be deleted. This path must not correspond to a file in the trash/deleted.
+   * @throws AccessControlException   If the current user cannot perform this operation.
+   * @throws NotFoundException        If the specified path does not exist, or the current user is not allowed to
+   *                                  access it.
+   * @throws OperationFailedException If the operation fails for some other (checked) reason.
+   */
+  default void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+    deleteFile( path, false );
+  }
 
   /**
    * Restores files, given their paths.
    *
-   * @param paths The list of file paths to be restored. These paths must correspond to files that are in the trash/deleted.
+   * @param paths The list of file paths to be restored. These paths must correspond to files that are in the
+   *              trash/deleted.
    * @throws AccessControlException        If the current user cannot perform this operation.
    * @throws BatchOperationFailedException If the batch operation fails for some reason.
    * @throws OperationFailedException      If the operation fails for some other (checked) reason.
@@ -346,11 +380,11 @@ public interface IGenericFileService {
   /**
    * Restores a file, given its path.
    *
-   * @param path The file path to be restored. This path must correspond to a file that is in the trash/deleted.
+   * @param path The file path to be restored. This path must correspond to a file in the trash/deleted.
    * @throws AccessControlException   If the current user cannot perform this operation.
    * @throws InvalidPathException     If the specified path is not valid.
-   * @throws NotFoundException        If the specified path does not exist, or does not correspond to a file that 
-   *                                  are in the trash/deleted, or the current user is not allowed to access it.
+   * @throws NotFoundException        If the specified path does not exist, or does not correspond to a file in the
+   *                                  trash/deleted, or the current user is not allowed to access it.
    * @throws OperationFailedException If the operation fails for some other (checked) reason.
    */
   void restoreFile( @NonNull GenericFilePath path ) throws OperationFailedException;

--- a/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
+++ b/api/src/main/java/org/pentaho/platform/api/genericfile/model/IGenericFileContentWrapper.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 
 // NOTE: Designed after the class
 // {@code org.pentaho.platform.web.http.api.resources.services.FileService.RepositoryFileToStreamWrapper}.
+
 /**
  * The {@code IGenericFileContentWrapper} interface contains the necessary information for returning a
  * {@code IGenericFile}'s content.

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/GetTreeOptionsTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/GetTreeOptionsTest.java
@@ -203,7 +203,7 @@ class GetTreeOptionsTest {
     void testAcceptsNullGenericPathList() throws InvalidPathException {
       GetTreeOptions options = new GetTreeOptions();
 
-      List<GenericFilePath> initialPaths = List.of( GenericFilePath.parseRequired( "/" ));
+      List<GenericFilePath> initialPaths = List.of( GenericFilePath.parseRequired( "/" ) );
       options.setExpandedPaths( initialPaths );
 
       options.setExpandedPaths( null );
@@ -272,7 +272,8 @@ class GetTreeOptionsTest {
   }
 
   /**
-   * Tests the {@link GetTreeOptions#getExpandedMaxDepth()} and {@link GetTreeOptions#setExpandedMaxDepth(Integer)} methods.
+   * Tests the {@link GetTreeOptions#getExpandedMaxDepth()} and {@link GetTreeOptions#setExpandedMaxDepth(Integer)}
+   * methods.
    */
   @Nested
   class ExpandedMaxDepthTests {

--- a/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
+++ b/api/src/test/java/org/pentaho/platform/api/genericfile/IGenericFileServiceTest.java
@@ -96,17 +96,17 @@ class IGenericFileServiceTest {
     }
 
     @Override
-    public void deleteFilePermanently(@NonNull GenericFilePath path) throws OperationFailedException {
+    public void deleteFilePermanently( @NonNull GenericFilePath path ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public void deleteFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException {
+    public void deleteFiles( @NonNull List<GenericFilePath> paths, boolean permanent ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public void deleteFile(@NonNull GenericFilePath path) throws OperationFailedException {
+    public void deleteFile( @NonNull GenericFilePath path, boolean permanent ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
 
@@ -116,7 +116,7 @@ class IGenericFileServiceTest {
     }
 
     @Override
-    public void restoreFile(@NonNull GenericFilePath path) throws OperationFailedException {
+    public void restoreFile( @NonNull GenericFilePath path ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
   }

--- a/impl/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
@@ -19,7 +19,6 @@ import org.pentaho.platform.api.genericfile.GetTreeOptions;
 import org.pentaho.platform.api.genericfile.IGenericFileProvider;
 import org.pentaho.platform.api.genericfile.exception.OperationFailedException;
 import org.pentaho.platform.api.genericfile.model.IGenericFile;
-import org.pentaho.platform.api.genericfile.model.IGenericFileContentWrapper;
 import org.pentaho.platform.api.genericfile.model.IGenericFileTree;
 import org.pentaho.platform.genericfile.model.BaseGenericFileTree;
 

--- a/impl/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/BaseGenericFileProvider.java
@@ -221,8 +221,8 @@ public abstract class BaseGenericFileProvider<T extends IGenericFile> implements
   }
 
   /**
-   * Recursively adds children to the given tree up to a given depth. If expandedMaxDepth is less than 1 or the tree root is
-   * not a folder, then nothing is done.
+   * Recursively adds children to the given tree up to a given depth. If expandedMaxDepth is less than 1 or the tree
+   * root is not a folder, then nothing is done.
    *
    * @param tree             The tree to which children will be added.
    * @param options          The get tree options.

--- a/impl/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/DefaultGenericFileService.java
@@ -267,12 +267,12 @@ public class DefaultGenericFileService implements IGenericFileService {
   }
 
   @Override
-  public void deleteFiles( @NonNull List<GenericFilePath> paths ) throws OperationFailedException {
+  public void deleteFiles( @NonNull List<GenericFilePath> paths, boolean permanent ) throws OperationFailedException {
     BatchOperationFailedException batchException = null;
 
     for ( GenericFilePath path : paths ) {
       try {
-        deleteFile( path );
+        deleteFile( path, permanent );
       } catch ( OperationFailedException e ) {
         if ( batchException == null ) {
           batchException =
@@ -289,10 +289,10 @@ public class DefaultGenericFileService implements IGenericFileService {
   }
 
   @Override
-  public void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+  public void deleteFile( @NonNull GenericFilePath path, boolean permanent ) throws OperationFailedException {
     getOwnerFileProvider( path )
       .orElseThrow( () -> new NotFoundException( String.format( "Path not found '%s'.", path ) ) )
-      .deleteFile( path );
+      .deleteFile( path, permanent );
   }
 
   @Override

--- a/impl/src/main/java/org/pentaho/platform/genericfile/messages/Messages.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/messages/Messages.java
@@ -13,15 +13,15 @@
 
 package org.pentaho.platform.genericfile.messages;
 
+import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.platform.util.messages.MessageUtil;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-
-import org.pentaho.platform.util.messages.LocaleHelper;
-import org.pentaho.platform.util.messages.MessageUtil;
 
 
 public class Messages {

--- a/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
@@ -505,9 +505,17 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
   }
 
   @Override
-  public void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+  public void deleteFile( @NonNull GenericFilePath path, boolean permanent ) throws OperationFailedException {
     try {
-      fileService.doDeleteFiles( getFileId( path ) );
+      String fileId = getFileId( path );
+
+      if ( permanent ) {
+        fileService.doDeleteFilesPermanent( fileId );
+      } else {
+        fileService.doDeleteFiles( fileId );
+      }
+    } catch ( FileNotFoundException e ) {
+      throw new NotFoundException( String.format( "Path not found '%s'.", path ), e );
     } catch ( Exception e ) {
       throw new OperationFailedException( e );
     }

--- a/impl/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/BaseGenericFileProviderTest.java
@@ -87,7 +87,7 @@ public class BaseGenericFileProviderTest {
     }
 
     @Override
-    public void deleteFile( @NonNull GenericFilePath path ) throws OperationFailedException {
+    public void deleteFile( @NonNull GenericFilePath path, boolean permanent ) throws OperationFailedException {
       throw new UnsupportedOperationException();
     }
 

--- a/impl/src/test/java/org/pentaho/platform/genericfile/DefaultGenericFileServiceTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/DefaultGenericFileServiceTest.java
@@ -420,7 +420,7 @@ public class DefaultGenericFileServiceTest {
     assertEquals( 1, failedFiles.size() );
     assertTrue( failedFiles.containsKey( useCase.path1 ) );
     assertEquals( "Path not found '" + useCase.path1 + "'.", failedFiles.get( useCase.path1 ).getMessage() );
-    assertEquals( NotFoundException.class, exception.getSuppressed()[0].getClass() );
+    assertEquals( NotFoundException.class, exception.getSuppressed()[ 0 ].getClass() );
     verify( useCase.provider1Mock, never() ).deleteFilePermanently( any( GenericFilePath.class ) );
   }
 

--- a/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
@@ -16,6 +16,8 @@ package org.pentaho.platform.genericfile.providers.repository;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.pentaho.platform.api.genericfile.GenericFilePath;
 import org.pentaho.platform.api.genericfile.GetTreeOptions;
 import org.pentaho.platform.api.genericfile.exception.InvalidPathException;
@@ -797,8 +799,9 @@ public class RepositoryFileProviderTest {
   // endregion
 
   // region deleteFile
-  @Test
-  public void testDeleteFileSuccess() throws Exception {
+  @ParameterizedTest
+  @ValueSource( booleans = { true, false } )
+  public void testDeleteFileSuccess( boolean permanent ) throws Exception {
     String fileId = "8b69da2b-2a10-4a82-89bc-a376e52d5482";
     GenericFilePath path = GenericFilePath.parse( "/home/admin/8b69da2b-2a10-4a82-89bc-a376e52d5482"
       + "/PAZReport.xanalyzer" );
@@ -809,13 +812,14 @@ public class RepositoryFileProviderTest {
     IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
     RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
 
-    repositoryProvider.deleteFile( path );
+    repositoryProvider.deleteFile( path, permanent );
 
     verify( fileServiceMock, times( 1 ) ).doDeleteFiles( fileId );
   }
 
-  @Test
-  public void testDeleteFileOperationFailed() throws Exception {
+  @ParameterizedTest
+  @ValueSource( booleans = { true, false } )
+  public void testDeleteFileOperationFailed( boolean permanent ) throws Exception {
     String fileId = "8b69da2b-2a10-4a82-89bc-a376e52d5482";
     GenericFilePath path = GenericFilePath.parse( "/home/admin/8b69da2b-2a10-4a82-89bc-a376e52d5482"
       + "/PAZReport.xanalyzer" );
@@ -828,13 +832,14 @@ public class RepositoryFileProviderTest {
 
     doThrow( new OperationFailedException() ).when( fileServiceMock ).doDeleteFiles( any() );
 
-    assertThrows( OperationFailedException.class, () -> repositoryProvider.deleteFile( path ) );
+    assertThrows( OperationFailedException.class, () -> repositoryProvider.deleteFile( path, permanent ) );
 
     verify( fileServiceMock ).doDeleteFiles( fileId );
   }
 
-  @Test
-  public void testDeleteFileNotFound() throws Exception {
+  @ParameterizedTest
+  @ValueSource( booleans = { true, false } )
+  public void testDeleteFileNotFound( boolean permanent ) throws Exception {
     GenericFilePath path = GenericFilePath.parse( "/home/admin/nonexistent-file.xanalyzer" );
 
     FileService fileServiceMock = mock( FileService.class );
@@ -842,7 +847,7 @@ public class RepositoryFileProviderTest {
     IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
     RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
 
-    assertThrows( OperationFailedException.class, () -> repositoryProvider.deleteFile( path ) );
+    assertThrows( OperationFailedException.class, () -> repositoryProvider.deleteFile( path, permanent ) );
 
     verify( fileServiceMock, never() ).doDeleteFiles( anyString() );
 }

--- a/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
@@ -15,7 +15,6 @@ package org.pentaho.platform.genericfile.providers.repository;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.pentaho.platform.api.genericfile.GenericFilePath;
@@ -740,12 +739,14 @@ public class RepositoryFileProviderTest {
 
   @Test
   public void testGetTrashFileIdInvalidPathWithoutColon() throws Exception {
-    testGetTrashFileIdInvalidPath( "/home/admin/.trash/8b69da2b-2a10-4a82-89bc-a376e52d5482/PAZReport.xanalyzer", InvalidPathException.class );
+    testGetTrashFileIdInvalidPath( "/home/admin/.trash/8b69da2b-2a10-4a82-89bc-a376e52d5482/PAZReport.xanalyzer",
+      InvalidPathException.class );
   }
 
   @Test
   public void testGetTrashFileIdInvalidPathNoTrash() throws Exception {
-    testGetTrashFileIdInvalidPath( "/home/admin/pho:8b69da2b-2a10-4a82-89bc-a376e52d5482/PAZReport.xanalyzer", NotFoundException.class );
+    testGetTrashFileIdInvalidPath( "/home/admin/pho:8b69da2b-2a10-4a82-89bc-a376e52d5482/PAZReport.xanalyzer",
+      NotFoundException.class );
   }
 
   @Test
@@ -765,10 +766,12 @@ public class RepositoryFileProviderTest {
 
   @Test
   public void testGetTrashFileIdInvalidPathNoTrashNoColon() throws Exception {
-    testGetTrashFileIdInvalidPath( "/home/admin/8b69da2b-2a10-4a82-89bc-a376e52d5482/PAZReport.xanalyzer", NotFoundException.class );
+    testGetTrashFileIdInvalidPath( "/home/admin/8b69da2b-2a10-4a82-89bc-a376e52d5482/PAZReport.xanalyzer",
+      NotFoundException.class );
   }
 
-  private <T extends Throwable> void testGetTrashFileIdInvalidPath( String pathString, Class<T> exceptionClass ) throws Exception {
+  private <T extends Throwable> void testGetTrashFileIdInvalidPath( String pathString, Class<T> exceptionClass )
+    throws Exception {
     GenericFilePath path = GenericFilePath.parse( pathString );
 
     FileService fileServiceMock = mock( FileService.class );
@@ -850,14 +853,14 @@ public class RepositoryFileProviderTest {
     assertThrows( OperationFailedException.class, () -> repositoryProvider.deleteFile( path, permanent ) );
 
     verify( fileServiceMock, never() ).doDeleteFiles( anyString() );
-}
+  }
 
   @NonNull
   private static RepositoryFileDto createSampleFile( String id ) {
     RepositoryFileDto file = createNativeFileDto( "/public/fileToDelete", "fileToDelete", false );
     file.setHidden( false );
     file.setId( id );
-    
+
     return file;
   }
   // endregion


### PR DESCRIPTION
@pentaho/millenniumfalcon please review

This pull request introduces significant enhancements to the file deletion functionality in the Pentaho platform, adding support for conditional deletion (permanent or trash) and improving test coverage. The changes primarily involve API updates, implementation adjustments, and corresponding test modifications.

### API Updates:
* Modified `deleteFile` and `deleteFiles` methods in `IGenericFileProvider` and `IGenericFileService` to include a `boolean permanent` parameter, allowing conditional deletion of files. Updated method documentation to reflect the new behavior. [[1]](diffhunk://#diff-be0fe333a36a507d46b3fb7aa0d6f5861eba6de460dafd85c7b8bff36cc390caL204-R225) [[2]](diffhunk://#diff-f742989aab35fb0c0cdd91e9788f1ac39f634b7bb1c5134377c92c181ddac60dL317-R336)

### Implementation Adjustments:
* Updated the `deleteFile` and `deleteFiles` methods in `DefaultGenericFileService` and `RepositoryFileProvider` to handle the `permanent` parameter. Added logic to differentiate between permanent deletion and sending files to the trash. [[1]](diffhunk://#diff-34c6ad546ad414c59a38f9c307f731b9c83df8c7dd0bc09c160acd34194c98a6L270-R275) [[2]](diffhunk://#diff-34c6ad546ad414c59a38f9c307f731b9c83df8c7dd0bc09c160acd34194c98a6L292-R295) [[3]](diffhunk://#diff-44974625ff45ff0f032a66db8e99fb8e1437ccd263c1772407ee70d1f8bf70b7L508-R516)

### Test Enhancements:
* Refactored existing unit tests in `DefaultGenericFileServiceTest` and `RepositoryFileProviderTest` to use parameterized tests, ensuring both permanent and trash deletion scenarios are covered. [[1]](diffhunk://#diff-3c1cef1e389a979865b28d74c5bfb85130b13e6531c2b522563b0c55b90040feR16-R17) [[2]](diffhunk://#diff-3c1cef1e389a979865b28d74c5bfb85130b13e6531c2b522563b0c55b90040feL480-R501) [[3]](diffhunk://#diff-4d79d5733745d141e3e26145d1b91809ef090639f3aac334aebc34a34e0d3ab5L800-R804)
* Added new test cases to validate the behavior of the updated `deleteFile` and `deleteFiles` methods under various conditions, including success, failure, and not-found scenarios. [[1]](diffhunk://#diff-3c1cef1e389a979865b28d74c5bfb85130b13e6531c2b522563b0c55b90040feL507-R523) [[2]](diffhunk://#diff-4d79d5733745d141e3e26145d1b91809ef090639f3aac334aebc34a34e0d3ab5L812-R822) [[3]](diffhunk://#diff-4d79d5733745d141e3e26145d1b91809ef090639f3aac334aebc34a34e0d3ab5L831-R850)

### Minor Changes:
* Removed an unused import in `BaseGenericFileProvider`.

These changes enhance the flexibility of file deletion operations while maintaining robust error handling and test coverage.