### PR TITLE
fix: delete returns 500 instead of 403 when resource access denied [PPUC-694][SP-7238]

### DIFF
--- a/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
@@ -645,6 +645,8 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
       } else {
         fileService.doDeleteFiles( fileId );
       }
+    } catch ( UnifiedRepositoryAccessDeniedException e ) {
+      throw new ResourceAccessDeniedException( "User is not authorized to delete this path.", path );
     } catch ( Exception e ) {
       throw new OperationFailedException( e );
     }

--- a/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
@@ -40,6 +40,7 @@ import org.pentaho.platform.api.importexport.ExportException;
 import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
 import org.pentaho.platform.api.repository2.unified.RepositoryFileSid;
 import org.pentaho.platform.api.repository2.unified.UnifiedRepositoryAccessDeniedException;
 import org.pentaho.platform.api.repository2.unified.UnifiedRepositoryException;
@@ -629,6 +630,114 @@ class RepositoryFileProviderTest {
     assertNull( tree.getFile().getMetadata() );
     verify( fileServiceMock, never() ).doGetMetadata( any() );
   }
+
+  @Test
+  void testGetTreeZeroDepthSetsChildrenToNull() throws OperationFailedException {
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( scenario.rootTree )
+      .when( fileServiceMock )
+      .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
+
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
+
+    GetTreeOptions options = new GetTreeOptions();
+    options.setBasePath( ROOT_PATH );
+    options.setMaxDepth( 0 );
+
+    IGenericFileTree tree = repositoryProvider.getTree( options );
+
+    assertNotNull( tree );
+    assertNull( tree.getChildren() );
+
+    // Zero depth workaround sends depth=1 to the backend.
+    verify( fileServiceMock, times( 1 ) ).doGetTree( ENCODED_ROOT_PATH, 1, ALL_FILTER, false, false, false );
+  }
+
+  @Test
+  void testGetTreeThrowsNotFoundWhenDoGetTreeReturnsNull() throws InvalidPathException {
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( null )
+      .when( fileServiceMock )
+      .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
+
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
+
+    GetTreeOptions options = new GetTreeOptions();
+    options.setBasePath( ROOT_PATH );
+    options.setMaxDepth( 1 );
+
+    assertThrows( NotFoundException.class, () -> repositoryProvider.getTree( options ) );
+  }
+
+  @Test
+  void testGetTreePassesIncludeHiddenToFileService() throws OperationFailedException {
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( scenario.rootTree )
+      .when( fileServiceMock )
+      .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
+
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
+
+    GetTreeOptions options = new GetTreeOptions();
+    options.setBasePath( ROOT_PATH );
+    options.setMaxDepth( 1 );
+    options.setIncludeHidden( true );
+
+    repositoryProvider.getTree( options );
+
+    verify( fileServiceMock, times( 1 ) ).doGetTree( ENCODED_ROOT_PATH, 1, ALL_FILTER, true, false, false );
+  }
+
+  @Test
+  void testGetTreePassesFoldersFilterToFileService() throws OperationFailedException {
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( scenario.rootTree )
+      .when( fileServiceMock )
+      .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
+
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
+
+    GetTreeOptions options = new GetTreeOptions();
+    options.setBasePath( ROOT_PATH );
+    options.setMaxDepth( 1 );
+    options.setFilter( GetTreeOptions.TreeFilter.FOLDERS );
+
+    repositoryProvider.getTree( options );
+
+    verify( fileServiceMock, times( 1 ) ).doGetTree( ENCODED_ROOT_PATH, 1, "*|FOLDERS", false, false, false );
+  }
+
+  @Test
+  void testGetTreePassesFilesFilterToFileService() throws OperationFailedException {
+    NativeDtoRepositoryScenario scenario = new NativeDtoRepositoryScenario();
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( scenario.rootTree )
+      .when( fileServiceMock )
+      .doGetTree( any(), any(), any(), anyBoolean(), anyBoolean(), anyBoolean() );
+
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
+
+    GetTreeOptions options = new GetTreeOptions();
+    options.setBasePath( ROOT_PATH );
+    options.setMaxDepth( 1 );
+    options.setFilter( GetTreeOptions.TreeFilter.FILES );
+
+    repositoryProvider.getTree( options );
+
+    verify( fileServiceMock, times( 1 ) ).doGetTree( ENCODED_ROOT_PATH, 1, "*|FILES", false, false, false );
+  }
   // endregion
 
   // region getRootTrees
@@ -1079,33 +1188,59 @@ class RepositoryFileProviderTest {
   @ParameterizedTest
   @ValueSource( booleans = { true, false } )
   void testDeleteFileResourceAccessDeniedException( boolean permanent ) throws Exception {
+    String fileId = "8b69da2b-2a10-4a82-89bc-a376e52d5482";
     GenericFilePath path = GenericFilePath.parse( "/home/admin/access-denied-file.xanalyzer" );
 
     FileService fileServiceMock = mock( FileService.class );
+
+    if ( permanent ) {
+      doThrow( UnifiedRepositoryAccessDeniedException.class ).when( fileServiceMock ).doDeleteFilesPermanent( any() );
+    } else {
+      doThrow( UnifiedRepositoryAccessDeniedException.class ).when( fileServiceMock ).doDeleteFiles( any() );
+    }
+
     IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
-    doThrow( UnifiedRepositoryAccessDeniedException.class ).when( repositoryMock ).getFile( any() );
+    doReturn( createNativeFile( fileId, path, false ) ).when( repositoryMock ).getFile( any() );
     RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
 
     assertThrows( ResourceAccessDeniedException.class, () -> repositoryProvider.deleteFile( path, permanent ) );
 
-    verify( fileServiceMock, never() ).doDeleteFiles( anyString() );
-    verify( fileServiceMock, never() ).doDeleteFilesPermanent( anyString() );
+    if ( permanent ) {
+      verify( fileServiceMock, never() ).doDeleteFiles( anyString() );
+      verify( fileServiceMock ).doDeleteFilesPermanent( fileId );
+    } else {
+      verify( fileServiceMock ).doDeleteFiles( fileId );
+      verify( fileServiceMock, never() ).doDeleteFilesPermanent( anyString() );
+    }
   }
 
   @ParameterizedTest
   @ValueSource( booleans = { true, false } )
   void testDeleteFileOperationFailedException( boolean permanent ) throws Exception {
+    String fileId = "8b69da2b-2a10-4a82-89bc-a376e52d5482";
     GenericFilePath path = GenericFilePath.parse( "/home/admin/exception-file.xanalyzer" );
 
     FileService fileServiceMock = mock( FileService.class );
+
+    if ( permanent ) {
+      doThrow( UnifiedRepositoryException.class ).when( fileServiceMock ).doDeleteFilesPermanent( any() );
+    } else {
+      doThrow( UnifiedRepositoryException.class ).when( fileServiceMock ).doDeleteFiles( any() );
+    }
+
     IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
-    doThrow( UnifiedRepositoryException.class ).when( repositoryMock ).getFile( any() );
+    doReturn( createNativeFile( fileId, path, false ) ).when( repositoryMock ).getFile( any() );
     RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
 
     assertThrows( OperationFailedException.class, () -> repositoryProvider.deleteFile( path, permanent ) );
 
-    verify( fileServiceMock, never() ).doDeleteFiles( anyString() );
-    verify( fileServiceMock, never() ).doDeleteFilesPermanent( anyString() );
+    if ( permanent ) {
+      verify( fileServiceMock, never() ).doDeleteFiles( anyString() );
+      verify( fileServiceMock ).doDeleteFilesPermanent( fileId );
+    } else {
+      verify( fileServiceMock ).doDeleteFiles( fileId );
+      verify( fileServiceMock, never() ).doDeleteFilesPermanent( anyString() );
+    }
   }
   // endregion
 
@@ -1314,6 +1449,52 @@ class RepositoryFileProviderTest {
       mocked.when( () -> SystemUtils.canDownload( null ) ).thenReturn( true );
 
       assertThrows( OperationFailedException.class, () -> repositoryProvider.getFileContent( path, true ) );
+    }
+  }
+
+  @Test
+  void testGetFileContentCompressedThrowsIOException() throws Exception {
+    String fileId = "file-123";
+    GenericFilePath path = GenericFilePath.parse( "/public/testFile1" );
+    RepositoryFile nativeFile = createNativeFile( fileId, path, false );
+
+    FileService fileServiceMock = mock( FileService.class );
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    doReturn( nativeFile ).when( repositoryMock ).getFile( path.toString() );
+    doReturn( true ).when( fileServiceMock ).isPathValid( path.toString() );
+    RepositoryFileProvider repositoryProvider = spy( new RepositoryFileProvider( repositoryMock, fileServiceMock ) );
+    doThrow( java.io.IOException.class ).when( repositoryProvider ).getFileContentCompressedStream( nativeFile );
+
+    try ( var mocked = mockStatic( SystemUtils.class ) ) {
+      mocked.when( () -> SystemUtils.canDownload( path.toString() ) ).thenReturn( true );
+      mocked.when( () -> SystemUtils.canDownload( null ) ).thenReturn( true );
+
+      assertThrows( OperationFailedException.class, () -> repositoryProvider.getFileContent( path, true ) );
+    }
+  }
+
+  @Test
+  void testGetFileContentCompressedFolderSuccess() throws Exception {
+    String fileId = "folder-123";
+    GenericFilePath path = GenericFilePath.parse( "/public/testFolder2" );
+    RepositoryFile nativeFile = createNativeFile( fileId, path, true );
+
+    FileService fileServiceMock = mock( FileService.class );
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    doReturn( nativeFile ).when( repositoryMock ).getFile( path.toString() );
+    doReturn( true ).when( fileServiceMock ).isPathValid( path.toString() );
+    FileInputStream compressedStream = mock( FileInputStream.class );
+    RepositoryFileProvider repositoryProvider = spy( new RepositoryFileProvider( repositoryMock, fileServiceMock ) );
+    doReturn( compressedStream ).when( repositoryProvider ).getFileContentCompressedStream( nativeFile );
+
+    try ( var mocked = mockStatic( SystemUtils.class ) ) {
+      mocked.when( () -> SystemUtils.canDownload( path.toString() ) ).thenReturn( true );
+      mocked.when( () -> SystemUtils.canDownload( null ) ).thenReturn( true );
+      IGenericFileContent content = repositoryProvider.getFileContent( path, true );
+
+      assertNotNull( content );
+      assertEquals( nativeFile.getName() + ".zip", content.getFileName() );
+      assertEquals( MediaType.ZIP.toString(), content.getMimeType() );
     }
   }
   // endregion compressed
@@ -1873,6 +2054,30 @@ class RepositoryFileProviderTest {
 
     assertEquals( "User is not authorized to rename this path.", exception.getMessage() );
     verify( fileServiceMock ).doRename( encodeRepositoryPath( path.toString() ), newName );
+  }
+
+  @Test
+  void testRenameFileSuccessWithNoExtension() throws Exception {
+    String fileId = "8b69da2b-2a10-4a82-89bc-a376e52d5482";
+    GenericFilePath path = GenericFilePath.parse( "/home/admin/" + fileId + "/myFolder" );
+    String newName = "renamedFolder";
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( "true" ).when( fileServiceMock ).doGetCanCreate();
+    doReturn( true ).when( fileServiceMock ).doesExist( encodeRepositoryPath( path.toString() ) );
+    doReturn( true ).when( fileServiceMock ).isValidFileName( newName, true );
+    doReturn( true ).when( fileServiceMock ).doRename( encodeRepositoryPath( path.toString() ), newName );
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
+
+    // No extension, so fullNewName == newName.
+    GenericFilePath newPath = repositoryProvider.getNewPath( path.getParent(), newName );
+    doReturn( false ).when( fileServiceMock ).doesExist( encodeRepositoryPath( newPath.toString() ) );
+
+    boolean result = repositoryProvider.renameFile( path, newName );
+
+    assertTrue( result );
+    verify( fileServiceMock, times( 1 ) ).doRename( encodeRepositoryPath( path.toString() ), newName );
   }
   // endregion
 
@@ -2449,6 +2654,18 @@ class RepositoryFileProviderTest {
   }
 
   @Test
+  void testDoesFolderExistReturnsFalseWhenNotFoundExceptionIsThrown() throws OperationFailedException {
+    GenericFilePath path = GenericFilePath.parse( "/public/nonexistent" );
+
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    FileService fileServiceMock = mock( FileService.class );
+    RepositoryFileProvider repositoryProvider = spy( new RepositoryFileProvider( repositoryMock, fileServiceMock ) );
+    doThrow( new NotFoundException( "Path not found.", path ) ).when( repositoryProvider ).getNativeFile( path );
+
+    assertFalse( repositoryProvider.doesFolderExist( path ) );
+  }
+
+  @Test
   void testDoesFolderExistThrowsResourceAccessDeniedException() throws OperationFailedException {
     GenericFilePath path = GenericFilePath.parse( "/public/testFile1" );
 
@@ -2457,7 +2674,7 @@ class RepositoryFileProviderTest {
     doThrow( UnifiedRepositoryAccessDeniedException.class ).when( repositoryMock ).getFile( path.toString() );
     RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
 
-    assertThrows( ResourceAccessDeniedException.class, () -> repositoryProvider.getFile( path, new GetFileOptions() ) );
+    assertThrows( ResourceAccessDeniedException.class, () -> repositoryProvider.doesFolderExist( path ) );
     verify( repositoryMock ).getFile( anyString() );
   }
 
@@ -2470,7 +2687,7 @@ class RepositoryFileProviderTest {
     doThrow( UnifiedRepositoryException.class ).when( repositoryMock ).getFile( path.toString() );
     RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
 
-    assertThrows( OperationFailedException.class, () -> repositoryProvider.getFile( path, new GetFileOptions() ) );
+    assertThrows( OperationFailedException.class, () -> repositoryProvider.doesFolderExist( path ) );
     verify( repositoryMock ).getFile( anyString() );
   }
   // endregion
@@ -2589,6 +2806,33 @@ class RepositoryFileProviderTest {
     assertFalse( repositoryProvider.hasAccess( path, EnumSet.of( GenericFilePermission.WRITE ) ) );
     verify( repositoryMock ).hasAccess( eq( path.toString() ), any() );
   }
+
+  @SuppressWarnings( "unchecked" )
+  @Test
+  void testHasAccessMapsAllPermissionTypes() throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/public/test" );
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    FileService fileServiceMock = mock( FileService.class );
+
+    ArgumentCaptor<EnumSet<RepositoryFilePermission>> captor =
+      ArgumentCaptor.forClass( EnumSet.class );
+    doReturn( true ).when( repositoryMock ).hasAccess( eq( path.toString() ), captor.capture() );
+
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
+
+    EnumSet<GenericFilePermission> allPermissions = EnumSet.allOf( GenericFilePermission.class );
+    assertTrue( repositoryProvider.hasAccess( path, allPermissions ) );
+
+    EnumSet<RepositoryFilePermission> expectedPermissions = EnumSet.of(
+      RepositoryFilePermission.READ,
+      RepositoryFilePermission.WRITE,
+      RepositoryFilePermission.DELETE,
+      RepositoryFilePermission.ACL_MANAGEMENT,
+      RepositoryFilePermission.ALL
+    );
+    EnumSet<RepositoryFilePermission> captured = captor.getValue();
+    assertEquals( expectedPermissions, captured );
+  }
   // endregion
 
   // region getType and getName
@@ -2658,6 +2902,21 @@ class RepositoryFileProviderTest {
   @Test
   void testConvertToNativeFileMetadataWithEmptyMap() {
     BaseGenericFileMetadata metadata = new BaseGenericFileMetadata();
+
+    IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
+    FileService fileServiceMock = mock( FileService.class );
+    RepositoryFileProvider repositoryProvider = new RepositoryFileProvider( repositoryMock, fileServiceMock );
+
+    List<StringKeyStringValueDto> result = repositoryProvider.convertToNativeFileMetadata( metadata );
+
+    assertNotNull( result );
+    assertTrue( result.isEmpty() );
+  }
+
+  @Test
+  void testConvertToNativeFileMetadataWithNullInnerMap() {
+    IGenericFileMetadata metadata = mock( IGenericFileMetadata.class );
+    doReturn( null ).when( metadata ).getMetadata();
 
     IUnifiedRepository repositoryMock = mock( IUnifiedRepository.class );
     FileService fileServiceMock = mock( FileService.class );


### PR DESCRIPTION
This pull request adds a comprehensive suite of new and improved unit tests for the `RepositoryFileProvider` class, increasing coverage for edge cases and error handling. The new tests validate behavior for file and folder operations, permission mappings, and error scenarios, ensuring the provider handles exceptions and input variations robustly.

**Unit Test Additions and Improvements:**

* Added tests for `getTree` to verify correct handling of zero depth, null returns, filter and hidden options, and error scenarios.
* Expanded tests for `deleteFile` to cover both permanent and non-permanent deletion, including handling of access denied and general repository exceptions, ensuring the correct exceptions are thrown and methods are invoked.
* Added tests for compressed file content retrieval, including handling of `IOException` and successful folder compression scenarios.
* Improved and added tests for folder existence checks to handle `NotFoundException`, `ResourceAccessDeniedException`, and `OperationFailedException`, ensuring correct boolean returns and exception propagation. [[1]](diffhunk://#diff-4d79d5733745d141e3e26145d1b91809ef090639f3aac334aebc34a34e0d3ab5R2656-R2667) [[2]](diffhunk://#diff-4d79d5733745d141e3e26145d1b91809ef090639f3aac334aebc34a34e0d3ab5L2460-R2677) [[3]](diffhunk://#diff-4d79d5733745d141e3e26145d1b91809ef090639f3aac334aebc34a34e0d3ab5L2473-R2690)
* Added tests to verify correct mapping of all `GenericFilePermission` types to `RepositoryFilePermission` in `hasAccess`.

**Bug Fixes and Exception Handling:**

* Updated `deleteFile` implementation to throw a `ResourceAccessDeniedException` when a `UnifiedRepositoryAccessDeniedException` is caught, improving error specificity.

**Code Robustness:**

* Added a test for `convertToNativeFileMetadata` to ensure it returns an empty list when the inner metadata map is null, preventing potential `NullPointerException`.

**Minor Test Additions:**

* Added a test for renaming a file/folder with no extension to ensure the new name is handled correctly.

**Test Imports:**

* Added missing import for `RepositoryFilePermission` to support new permission mapping tests.

@pentaho/millenniumfalcon please review