### PR TITLE
fix: return 403 instead of 500 when resource access denied [PPUC-745]

### DIFF
--- a/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
+++ b/impl/src/main/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProvider.java
@@ -812,7 +812,7 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
     try {
       return convertFromNativeFileAcl( fileService.doGetFileAcl( pathString, forceInheriting ) );
     } catch ( UnifiedRepositoryAccessDeniedException e ) {
-      throw new ResourceAccessDeniedException( "User is not authorized to get this path.", path );
+      throw new ResourceAccessDeniedException( "User is not authorized to get the ACL for this path.", path );
     } catch ( InvalidOperationException e ) {
       throw e;
     } catch ( Exception e ) {
@@ -835,7 +835,13 @@ public class RepositoryFileProvider extends BaseGenericFileProvider<RepositoryFi
     } catch ( FileNotFoundException e ) {
       throw new NotFoundException( String.format( "Path not found '%s'.", path ), path, e );
     } catch ( UnifiedRepositoryAccessDeniedException e ) {
-      throw new ResourceAccessDeniedException( "User is not authorized to get this path.", path );
+      throw new ResourceAccessDeniedException( "User is not authorized to set the ACL for this path.", path );
+    } catch ( UnifiedRepositoryException e ) {
+      if ( e.getCause() instanceof UnifiedRepositoryAccessDeniedException ) {
+        throw new ResourceAccessDeniedException( "User is not authorized to set the ACL for this path.", path );
+      }
+
+      throw new OperationFailedException( e );
     } catch ( Exception e ) {
       throw new OperationFailedException( e );
     }

--- a/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
+++ b/impl/src/test/java/org/pentaho/platform/genericfile/providers/repository/RepositoryFileProviderTest.java
@@ -2698,6 +2698,68 @@ class RepositoryFileProviderTest {
 
     assertThrows( OperationFailedException.class, () -> repositoryProvider.getFileAcl( path, forceInheriting ) );
   }
+
+  @ParameterizedTest
+  @ValueSource( booleans = { true, false } )
+  void testGetFileAclVerifiesEncodedPathIsPassed( boolean forceInheriting ) throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/public/testFile1" );
+    String encodedPath = encodeRepositoryPath( path.toString() );
+
+    RepositoryFileAclDto nativeAcl = mock( RepositoryFileAclDto.class );
+    IGenericFileAcl acl = mock( IGenericFileAcl.class );
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( true ).when( fileServiceMock ).doesExist( encodedPath );
+    doReturn( nativeAcl ).when( fileServiceMock ).doGetFileAcl( encodedPath, forceInheriting );
+
+    RepositoryFileProvider repositoryProvider = spy(
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock ) );
+    doReturn( acl ).when( repositoryProvider ).convertFromNativeFileAcl( nativeAcl );
+
+    repositoryProvider.getFileAcl( path, forceInheriting );
+
+    verify( fileServiceMock ).doesExist( encodedPath );
+    verify( fileServiceMock ).doGetFileAcl( encodedPath, forceInheriting );
+    verify( repositoryProvider ).convertFromNativeFileAcl( nativeAcl );
+  }
+
+  @ParameterizedTest
+  @ValueSource( booleans = { true, false } )
+  void testGetFileAclReturnsConvertedAclWithCorrectProperties( boolean forceInheriting ) throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/public/testFile1" );
+    String encodedPath = encodeRepositoryPath( path.toString() );
+
+    RepositoryFileAclDto nativeAcl = new RepositoryFileAclDto();
+    nativeAcl.setOwner( "owner1" );
+    nativeAcl.setOwnerType( 0 ); // USER
+
+    RepositoryFileAclAceDto ace = new RepositoryFileAclAceDto();
+    ace.setRecipient( "user1" );
+    ace.setRecipientType( 0 ); // USER
+    ace.setModifiable( true );
+    ace.setPermissions( List.of( 0, 1 ) ); // READ, WRITE
+    nativeAcl.setAces( List.of( ace ), forceInheriting );
+
+    FileService fileServiceMock = mock( FileService.class );
+    doReturn( true ).when( fileServiceMock ).doesExist( encodedPath );
+    doReturn( nativeAcl ).when( fileServiceMock ).doGetFileAcl( encodedPath, forceInheriting );
+
+    RepositoryFileProvider repositoryProvider =
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock );
+
+    IGenericFileAcl result = repositoryProvider.getFileAcl( path, forceInheriting );
+
+    assertNotNull( result );
+    assertEquals( "owner1", result.getOwner() );
+    assertEquals( GenericFilePrincipalType.USER, result.getOwnerType() );
+    assertEquals( forceInheriting, result.isEntriesInheriting() );
+    assertNotNull( result.getEntries() );
+    assertEquals( 1, result.getEntries().size() );
+    assertEquals( "user1", result.getEntries().get( 0 ).getRecipient() );
+    assertEquals( 2, result.getEntries().get( 0 ).getPermissions().size() );
+    assertEquals( GenericFilePermission.READ, result.getEntries().get( 0 ).getPermissions().get( 0 ) );
+    assertEquals( GenericFilePermission.WRITE, result.getEntries().get( 0 ).getPermissions().get( 1 ) );
+  }
   // endregion
 
   // region setFileAcl
@@ -2780,6 +2842,59 @@ class RepositoryFileProviderTest {
     doReturn( true ).when( repositoryProvider ).validateFileAcl( acl );
     doThrow( new RuntimeException( "acl set failed" ) ).when( fileServiceMock )
       .setFileAcls( encodeRepositoryPath( path.toString() ), nativeAcl );
+
+    assertThrows( OperationFailedException.class, () -> repositoryProvider.setFileAcl( path, acl ) );
+  }
+
+  @Test
+  void testSetFileAclUnifiedRepositoryExceptionWithAccessDeniedCause() throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/public/testFile1" );
+    IGenericFileAcl acl = mock( IGenericFileAcl.class );
+    RepositoryFileAclDto nativeAcl = mock( RepositoryFileAclDto.class );
+
+    FileService fileServiceMock = mock( FileService.class );
+    UnifiedRepositoryException wrappedException =
+      new UnifiedRepositoryException( new UnifiedRepositoryAccessDeniedException( "wrapped access denied" ) );
+    doThrow( wrappedException ).when( fileServiceMock ).setFileAcls( any(), any() );
+    RepositoryFileProvider repositoryProvider = spy(
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock ) );
+    doReturn( nativeAcl ).when( repositoryProvider ).convertToNativeFileAcl( acl );
+    doReturn( true ).when( repositoryProvider ).validateFileAcl( acl );
+
+    assertThrows( ResourceAccessDeniedException.class, () -> repositoryProvider.setFileAcl( path, acl ) );
+  }
+
+  @Test
+  void testSetFileAclUnifiedRepositoryExceptionWithOtherCause() throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/public/testFile1" );
+    IGenericFileAcl acl = mock( IGenericFileAcl.class );
+    RepositoryFileAclDto nativeAcl = mock( RepositoryFileAclDto.class );
+
+    FileService fileServiceMock = mock( FileService.class );
+    UnifiedRepositoryException wrappedException =
+      new UnifiedRepositoryException( new RuntimeException( "other cause" ) );
+    doThrow( wrappedException ).when( fileServiceMock ).setFileAcls( any(), any() );
+    RepositoryFileProvider repositoryProvider = spy(
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock ) );
+    doReturn( nativeAcl ).when( repositoryProvider ).convertToNativeFileAcl( acl );
+    doReturn( true ).when( repositoryProvider ).validateFileAcl( acl );
+
+    assertThrows( OperationFailedException.class, () -> repositoryProvider.setFileAcl( path, acl ) );
+  }
+
+  @Test
+  void testSetFileAclUnifiedRepositoryExceptionWithNullCause() throws Exception {
+    GenericFilePath path = GenericFilePath.parse( "/public/testFile1" );
+    IGenericFileAcl acl = mock( IGenericFileAcl.class );
+    RepositoryFileAclDto nativeAcl = mock( RepositoryFileAclDto.class );
+
+    FileService fileServiceMock = mock( FileService.class );
+    UnifiedRepositoryException wrappedException = new UnifiedRepositoryException( "no cause" );
+    doThrow( wrappedException ).when( fileServiceMock ).setFileAcls( any(), any() );
+    RepositoryFileProvider repositoryProvider = spy(
+      new RepositoryFileProvider( mock( IUnifiedRepository.class ), fileServiceMock ) );
+    doReturn( nativeAcl ).when( repositoryProvider ).convertToNativeFileAcl( acl );
+    doReturn( true ).when( repositoryProvider ).validateFileAcl( acl );
 
     assertThrows( OperationFailedException.class, () -> repositoryProvider.setFileAcl( path, acl ) );
   }


### PR DESCRIPTION
This pull request improves error handling and test coverage for ACL (Access Control List) operations in the `RepositoryFileProvider` class. The main changes clarify error messages, handle wrapped exceptions more robustly, and add comprehensive unit tests to ensure correct behavior when getting and setting file ACLs.

**Error Handling Improvements:**

* Updated error messages in `getFileAcl` and `setFileAcl` to specify whether the user is unauthorized to "get" or "set" the ACL for a path, providing clearer feedback to users and developers. [[1]](diffhunk://#diff-44974625ff45ff0f032a66db8e99fb8e1437ccd263c1772407ee70d1f8bf70b7L815-R815) [[2]](diffhunk://#diff-44974625ff45ff0f032a66db8e99fb8e1437ccd263c1772407ee70d1f8bf70b7L838-R844)
* Enhanced exception handling in `setFileAcl` to properly handle `UnifiedRepositoryException` by checking its cause: if it's an access denied exception, throw a `ResourceAccessDeniedException`; otherwise, throw an `OperationFailedException`.

**Expanded Unit Test Coverage:**

* Added parameterized tests to verify that `getFileAcl` passes the correctly encoded path to the underlying file service and that the returned ACL object has the expected properties.
* Added tests for `setFileAcl` to ensure correct exception handling when a `UnifiedRepositoryException` is thrown, including cases where the cause is an access denied exception, another type of exception, or null.

@pentaho/millenniumfalcon please review